### PR TITLE
Set explicit content-type header for XMLHttpRequest transport

### DIFF
--- a/packages/core/src/transport.ts
+++ b/packages/core/src/transport.ts
@@ -25,6 +25,11 @@ export class HttpRequest {
     }
     const request = new XMLHttpRequest()
     request.open('POST', url, true)
+    //
+    // setRequestHeader must be called after open() but before send(), per the spec:
+    // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader
+    //
+    request.setRequestHeader('Content-Type', 'text/plain;charset=UTF-8');
     request.send(data)
   }
 }


### PR DESCRIPTION
## Motivation

The current transport implementation relies on the default content-type for XMLHttpRequest, and it seems the datadog API is expecting this content type. We have an XMLHttpRequest shim that uses formdata as the default and figured it'd be worthwhile being explicit in this usage vs. changing the shim.

## Changes

Explicitly set the content-type we're sending

## Testing

No automated tests - I verified the header that was being sent with a test case outside of our project, and that this change reflects the same default header and overrides the formdata default for our shim.